### PR TITLE
[BUGFIX] Fix #5: tag link viewhelper creates a wrong link outside of EXT:blog plugins

### DIFF
--- a/Classes/ViewHelpers/Link/ArchiveViewHelper.php
+++ b/Classes/ViewHelpers/Link/ArchiveViewHelper.php
@@ -65,7 +65,7 @@ class ArchiveViewHelper extends AbstractTagBasedViewHelper
                 ->setFormat('rss')
                 ->setTargetPageType($this->getTypoScriptFrontendController()->tmpl->setup['blog_rss_archive.']['typeNum']);
         }
-        $uri = $uriBuilder->uriFor('listPostsByDate', [], 'Post');
+        $uri = $uriBuilder->uriFor('listPostsByDate', [], 'Post', 'Blog');
         if ($uri !== '') {
             $this->tag->addAttribute('href', $uri);
             $this->tag->setContent($this->renderChildren());

--- a/Classes/ViewHelpers/Link/AuthorViewHelper.php
+++ b/Classes/ViewHelpers/Link/AuthorViewHelper.php
@@ -83,7 +83,7 @@ class AuthorViewHelper extends AbstractTagBasedViewHelper
             $rssFormat
         );
 
-        return $this->buildAnchorTag($uriBuilder->uriFor('listPostsByAuthor', [], 'Post'), $author);
+        return $this->buildAnchorTag($uriBuilder->uriFor('listPostsByAuthor', [], 'Post'), $author, 'Blog');
     }
 
     /**

--- a/Classes/ViewHelpers/Link/CategoryViewHelper.php
+++ b/Classes/ViewHelpers/Link/CategoryViewHelper.php
@@ -62,7 +62,7 @@ class CategoryViewHelper extends AbstractTagBasedViewHelper
                 ->setFormat('rss')
                 ->setTargetPageType($this->getTypoScriptFrontendController()->tmpl->setup['blog_rss_category.']['typeNum']);
         }
-        $uri = $uriBuilder->uriFor('listPostsByCategory', [], 'Post');
+        $uri = $uriBuilder->uriFor('listPostsByCategory', [], 'Post', 'Blog');
 
         if ($uri !== '') {
             $linkText = $this->renderChildren() ?: $category->getTitle();

--- a/Classes/ViewHelpers/Link/TagViewHelper.php
+++ b/Classes/ViewHelpers/Link/TagViewHelper.php
@@ -62,7 +62,7 @@ class TagViewHelper extends AbstractTagBasedViewHelper
                 ->setFormat('rss')
                 ->setTargetPageType($this->getTypoScriptFrontendController()->tmpl->setup['blog_rss_tag.']['typeNum']);
         }
-        $uri = $uriBuilder->uriFor('listPostsByTag', [], 'Post');
+        $uri = $uriBuilder->uriFor('listPostsByTag', [], 'Post', 'Blog');
         if ($uri !== '') {
             $linkText = $this->renderChildren() ?: $tag->getTitle();
             $this->tag->addAttribute('href', $uri);


### PR DESCRIPTION
Fixed by adding `$extensionName` parameter to the uriBuilder call.