### PR TITLE
[BUGFIX] Avoid exception when accessing uninitialized settings

### DIFF
--- a/Classes/Controller/PostController.php
+++ b/Classes/Controller/PostController.php
@@ -21,7 +21,6 @@ use T3G\AgencyPack\Blog\Domain\Repository\TagRepository;
 use T3G\AgencyPack\Blog\Service\CacheService;
 use T3G\AgencyPack\Blog\Service\MetaService;
 use T3G\AgencyPack\Blog\Utility\ArchiveUtility;
-use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Extbase\Mvc\View\ViewInterface;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
@@ -149,7 +148,7 @@ class PostController extends ActionController
      */
     public function listRecentPostsAction(): void
     {
-        $maximumItems = (int)ArrayUtility::getValueByPath($this->settings, 'lists.posts.maximumDisplayedItems', '.') ?: 0;
+        $maximumItems = (int) (isset($this->settings['lists']['posts']['maximumDisplayedItems']) ? $this->settings['lists']['posts']['maximumDisplayedItems'] : 0);
 
         $posts = (0 === $maximumItems)
             ? $this->postRepository->findAll()

--- a/Classes/Controller/PostController.php
+++ b/Classes/Controller/PostController.php
@@ -148,8 +148,7 @@ class PostController extends ActionController
      */
     public function listRecentPostsAction(): void
     {
-        $maximumItems = (int) (isset($this->settings['lists']['posts']['maximumDisplayedItems']) ? $this->settings['lists']['posts']['maximumDisplayedItems'] : 0);
-
+        $maximumItems = (int) ($this->settings['lists']['posts']['maximumDisplayedItems'] ?? 0);
         $posts = (0 === $maximumItems)
             ? $this->postRepository->findAll()
             : $this->postRepository->findAllWithLimit($maximumItems);


### PR DESCRIPTION
Fixes: #49 
Releases: master, 9.1, 9.0, 8.7, 7.6