### PR TITLE
[BUGFIX] Only add storage constraint if pages could be resolved

### DIFF
--- a/Classes/Domain/Repository/CommentRepository.php
+++ b/Classes/Domain/Repository/CommentRepository.php
@@ -121,14 +121,16 @@ class CommentRepository extends Repository
         $query = $this->createQuery();
 
         $constraints = [];
-
         $constraints = $this->fillConstraintsBySettings($query, $constraints);
 
         if ($limit !== null) {
             $query->setLimit($limit);
         }
         if ($blogSetup !== null) {
-            $constraints[] = $query->in('pid', $this->getPostPidsByRootPid($blogSetup));
+            $storagePids = $this->getPostPidsByRootPid($blogSetup);
+            if (!empty($storagePids)) {
+                $constraints[] = $query->in('pid', $storagePids);
+            }
         }
         return $query->matching($query->logicalAnd($constraints))->execute();
     }


### PR DESCRIPTION
Fixes: #64
Releases: master, 9.1, 9.0, 8.7