### PR TITLE
[!!!][TASK] Remove obsolete sidebar headline

### DIFF
--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -36,9 +36,6 @@
 			<trans-unit id="headline.tags" xml:space="preserve">
 				<source>Tags</source>
 			</trans-unit>
-			<trans-unit id="headline.sidebar" xml:space="preserve">
-				<source>Sidebar</source>
-			</trans-unit>
 			<trans-unit id="headline.rssfeed" xml:space="preserve">
 				<source>RSS-Feeds</source>
 			</trans-unit>

--- a/Resources/Private/Templates/Post/Sidebar.html
+++ b/Resources/Private/Templates/Post/Sidebar.html
@@ -1,7 +1,6 @@
 <f:layout name="Default" />
 
 <f:section name="content">
-    <h2><f:translate key="headline.sidebar"/></h2>
     <f:for each="{settings.sidebarWidgets}" as="widget">
         <f:cObject typoscriptObjectPath="{widget}" />
     </f:for>


### PR DESCRIPTION
The sidebar headline does not deliver any benefit. The user has the option
to use the title of the content element to add a headline to the sidebar if
nessesary, in general this has no real usecase since only the headlines
of the widgets are relevant.

Releases: master