### PR TITLE
[BUGFIX] Respect translation settings in archive widget

### DIFF
--- a/Classes/Domain/Model/Post.php
+++ b/Classes/Domain/Model/Post.php
@@ -110,6 +110,16 @@ class Post extends AbstractEntity
     protected $publishDate;
 
     /**
+     * @var int
+     */
+    protected $crdateMonth = 0;
+
+    /**
+     * @var int
+     */
+    protected $crdateYear = 0;
+
+    /**
      * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\T3G\AgencyPack\Blog\Domain\Model\Author>
      * @Extbase\ORM\Lazy
      */
@@ -480,6 +490,22 @@ class Post extends AbstractEntity
     {
         $this->publishDate = $publishDate;
         return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCrdateMonth(): int
+    {
+        return $this->crdateMonth;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCrdateYear(): int
+    {
+        return $this->crdateYear;
     }
 
     /**


### PR DESCRIPTION
The current implementation also takes translations into
account. This leads to incorrect results for if you have
translated posts, or set a different fallback behavior.

We now also use the Extbase-QueryBuilder for the archive
widget to automatically respect these settings and deliver
the correct results. 

Since TYPO3 8.7 is relying on page_language_overlay,
this problem only occurs in the 9.x and 10.x versions.

Releases: master, 9.1, 9.0