### PR TITLE
[BUGFIX] Set default doktype for post model

### DIFF
--- a/Classes/Domain/Model/Post.php
+++ b/Classes/Domain/Model/Post.php
@@ -21,6 +21,13 @@ use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 class Post extends AbstractEntity
 {
     /**
+     * The blog post doktype
+     *
+     * @var int
+     */
+    protected $doktype = 137;
+
+    /**
      * The blog post title.
      *
      * @var string

--- a/Classes/Domain/Model/Post.php
+++ b/Classes/Domain/Model/Post.php
@@ -10,6 +10,7 @@ declare(strict_types = 1);
 
 namespace T3G\AgencyPack\Blog\Domain\Model;
 
+use T3G\AgencyPack\Blog\Constants;
 use T3G\AgencyPack\Blog\Domain\Repository\CommentRepository;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Annotation as Extbase;
@@ -25,7 +26,7 @@ class Post extends AbstractEntity
      *
      * @var int
      */
-    protected $doktype = 137;
+    protected $doktype = Constants::DOKTYPE_BLOG_POST;
 
     /**
      * The blog post title.
@@ -150,6 +151,14 @@ class Post extends AbstractEntity
         $this->tags = new ObjectStorage();
         $this->authors = new ObjectStorage();
         $this->media = new ObjectStorage();
+    }
+
+    /**
+     * @return int
+     */
+    public function getDoktype(): ?int
+    {
+        return $this->doktype;
     }
 
     /**

--- a/Tests/Unit/Domain/Model/PostTest.php
+++ b/Tests/Unit/Domain/Model/PostTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the package t3g/blog.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace T3G\AgencyPack\Blog\Tests\Unit\Domain\Model;
+
+use T3G\AgencyPack\Blog\Constants;
+use T3G\AgencyPack\Blog\Domain\Model\Post;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * Tests for domains model News
+ *
+ */
+class PostTest extends UnitTestCase
+{
+    /**
+     * @test
+     */
+    public function doktypeEqualsConstant()
+    {
+        $post = new Post();
+        self::assertEquals(Constants::DOKTYPE_BLOG_POST, $post->getDoktype());
+    }
+}


### PR DESCRIPTION
Set the correct doktype via the post model. This is required when posts
are created via Extbase, in an action or a command for example.

Fixes #82 