### PR TITLE
[!!!][TASK] Add configuration error note for single view plugins

### DIFF
--- a/Classes/Controller/CommentController.php
+++ b/Classes/Controller/CommentController.php
@@ -83,6 +83,7 @@ class CommentController extends ActionController
                 $this->blogCacheService->addTagToPage('tx_blog_comment_' . $comment->getUid());
             }
             $this->view->assign('comments', $comments);
+            $this->view->assign('post', $post);
         }
     }
 }

--- a/Classes/Controller/PostController.php
+++ b/Classes/Controller/PostController.php
@@ -363,7 +363,7 @@ class PostController extends ActionController
             (int)$this->settings['relatedPosts']['limit']
         );
         $this->view->assign('type', 'related');
-        $this->view->assign('currentPost', $post);
+        $this->view->assign('post', $post);
         $this->view->assign('posts', $posts);
     }
 

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -4,6 +4,14 @@
         <header/>
         <body>
 
+            <!-- General -->
+            <trans-unit id="general.message.configuration_error.title" xml:space="preserve">
+                <source>A possible configuration error was detected.</source>
+            </trans-unit>
+            <trans-unit id="general.message.configuration_error.single_no_post" xml:space="preserve">
+                <source>No matching post could be obtained. Make sure that this plugin is only used on a post.</source>
+            </trans-unit>
+
             <!-- Headline -->
             <trans-unit id="headline.commentform" xml:space="preserve">
                 <source>Write comment</source>

--- a/Resources/Private/Layouts/Post.html
+++ b/Resources/Private/Layouts/Post.html
@@ -1,0 +1,13 @@
+<f:spaceless>
+    <f:if condition="{post}">
+        <f:then>
+            <f:render section="Content" />
+        </f:then>
+        <f:else>
+            <div class="alert alert-danger" role="alert">
+                <div class="alert__title"><f:translate key="general.message.configuration_error.title"/></div>
+                <div class="alert__message"><f:translate key="general.message.configuration_error.single_no_post"/></div>
+            </div>
+        </f:else>
+    </f:if>
+</f:spaceless>

--- a/Resources/Private/Templates/Comment/Comments.html
+++ b/Resources/Private/Templates/Comment/Comments.html
@@ -1,4 +1,6 @@
-<f:spaceless>
+<f:layout name="Post" />
+<f:section name="Content">
+
     <f:if condition="{settings.comments.active}">
         <div class="postcomments">
             <h3 class="postcomments__title" id="comments"><f:translate key="headline.comments"/></h3>
@@ -18,4 +20,5 @@
             </f:if>
         </div>
     </f:if>
-</f:spaceless>
+
+</f:section>

--- a/Resources/Private/Templates/Comment/Form.html
+++ b/Resources/Private/Templates/Comment/Form.html
@@ -1,8 +1,13 @@
-<f:if condition="{post} && {settings.comments.active}">
-    <div class="postcommentsform" id="postcommentform-{post.uid}">
-        <f:variable name="formName" value="Local" />
-        <f:if condition="{settings.comments.disqus._typoScriptNodeValue}"><f:variable name="formName" value="Disqus" /></f:if>
-        <f:if condition="{post.commentsActive}"><f:else><f:variable name="formName" value="Closed" /></f:else></f:if>
-        <f:render partial="Comments/Form/{formName}" arguments="{_all}" />
-    </div>
-</f:if>
+<f:layout name="Post" />
+<f:section name="Content">
+
+    <f:if condition="{post} && {settings.comments.active}">
+        <div class="postcommentsform" id="postcommentform-{post.uid}">
+            <f:variable name="formName" value="Local" />
+            <f:if condition="{settings.comments.disqus._typoScriptNodeValue}"><f:variable name="formName" value="Disqus" /></f:if>
+            <f:if condition="{post.commentsActive}"><f:else><f:variable name="formName" value="Closed" /></f:else></f:if>
+            <f:render partial="Comments/Form/{formName}" arguments="{_all}" />
+        </div>
+    </f:if>
+
+</f:section>

--- a/Resources/Private/Templates/Post/Authors.html
+++ b/Resources/Private/Templates/Post/Authors.html
@@ -1,4 +1,6 @@
-<f:spaceless>
+<f:layout name="Post" />
+<f:section name="Content">
+
     <f:if condition="{post.authors}">
         <div class="postauthors">
             <f:for each="{post.authors}" as="author">
@@ -6,4 +8,5 @@
             </f:for>
         </div>
     </f:if>
-</f:spaceless>
+
+</f:section>

--- a/Resources/Private/Templates/Post/Footer.html
+++ b/Resources/Private/Templates/Post/Footer.html
@@ -1,4 +1,6 @@
-<f:spaceless>
+<f:layout name="Post" />
+<f:section name="Content">
+
     <footer class="postfooter">
         <f:if condition="{settings.meta.postfooter.enable}">
             <div class="postfooter__meta">
@@ -6,4 +8,5 @@
             </div>
         </f:if>
     </footer>
-</f:spaceless>
+
+</f:section>

--- a/Resources/Private/Templates/Post/Header.html
+++ b/Resources/Private/Templates/Post/Header.html
@@ -1,4 +1,6 @@
-<f:spaceless>
+<f:layout name="Post" />
+<f:section name="Content">
+
     <header class="postheader">
         <h1 class="postheader__title">{post.title}</h1>
         <f:if condition="{settings.meta.postheader.enable}">
@@ -7,4 +9,5 @@
             </div>
         </f:if>
     </header>
-</f:spaceless>
+
+</f:section>

--- a/Resources/Private/Templates/Post/Metadata.html
+++ b/Resources/Private/Templates/Post/Metadata.html
@@ -1,3 +1,6 @@
-<f:spaceless>
+<f:layout name="Post" />
+<f:section name="Content">
+
     <f:render partial="Meta/Default" arguments="{_all}" />
-</f:spaceless>
+
+</f:section>

--- a/Resources/Private/Templates/Post/RelatedPosts.html
+++ b/Resources/Private/Templates/Post/RelatedPosts.html
@@ -1,4 +1,6 @@
-<f:layout name="Default" />
+<f:layout name="Post" />
 <f:section name="Content">
+
     <f:render partial="SimpleList" arguments="{_all}" />
+
 </f:section>


### PR DESCRIPTION
To prevent the usage of plugins that should only be
used on post views we are now adding additional 
checks for those. If no post could be resolved - also 
means if the plugin is used on pages that do not match
the `Constants::DOKTYPE_BLOG_POST` - the plugins will
now return a new message to make the miss usage visible.

```
A possible configuration error was detected.
No matching post could be obtained. Make sure that this plugin is only used on a post.
```

The following plugins will now show this message if no 
post could be obtained:
* Authors
* Footer
* Header
* Metadata
* RelatedPosts

Templates added:
* Layouts/Post.html

Templates changed:
* Templates/Comment/Comments.html
* Templates/Comment/Form.html
* Templates/Post/Authors.html
* Templates/Post/Footer.html
* Templates/Post/Header.html
* Templates/Post/Metadata.html
* Templates/Post/RelatedPosts.html

Releases: master