### PR TITLE
add option to disable tag/category releated search

### DIFF
--- a/Classes/Domain/Repository/PostRepository.php
+++ b/Classes/Domain/Repository/PostRepository.php
@@ -306,34 +306,38 @@ class PostRepository extends Repository
 
         $currentPost = $this->findCurrentPost();
         if ($currentPost instanceof Post) {
-            foreach ($currentPost->getCategories() as $category) {
-                $postsOfCategory = $this->findAllByCategory($category);
-                /** @var Post $postOfCategory */
-                foreach ($postsOfCategory as $postOfCategory) {
-                    if ($postOfCategory->getUid() === $currentPost->getUid()) {
-                        continue;
-                    }
+            if ($categoryMultiplier > 0) {
+                foreach ($currentPost->getCategories() as $category) {
+                    $postsOfCategory = $this->findAllByCategory($category);
+                    /** @var Post $postOfCategory */
+                    foreach ($postsOfCategory as $postOfCategory) {
+                        if ($postOfCategory->getUid() === $currentPost->getUid()) {
+                            continue;
+                        }
 
-                    if (!array_key_exists($postOfCategory->getUid(), $selectedPosts)) {
-                        $selectedPosts[$postOfCategory->getUid()] = $categoryMultiplier;
-                    } else {
-                        $selectedPosts[$postOfCategory->getUid()] += $categoryMultiplier;
+                        if (!array_key_exists($postOfCategory->getUid(), $selectedPosts)) {
+                            $selectedPosts[$postOfCategory->getUid()] = $categoryMultiplier;
+                        } else {
+                            $selectedPosts[$postOfCategory->getUid()] += $categoryMultiplier;
+                        }
                     }
                 }
             }
 
-            foreach ($currentPost->getTags() as $tag) {
-                $postsOfTag = $this->findAllByTag($tag);
-                /** @var Post $postOfTag */
-                foreach ($postsOfTag as $postOfTag) {
-                    if ($postOfTag->getUid() === $currentPost->getUid()) {
-                        continue;
-                    }
+            if ($tagMultiplier > 0) {
+                foreach ($currentPost->getTags() as $tag) {
+                    $postsOfTag = $this->findAllByTag($tag);
+                    /** @var Post $postOfTag */
+                    foreach ($postsOfTag as $postOfTag) {
+                        if ($postOfTag->getUid() === $currentPost->getUid()) {
+                            continue;
+                        }
 
-                    if (!array_key_exists($postOfTag->getUid(), $selectedPosts)) {
-                        $selectedPosts[$postOfTag->getUid()] = $tagMultiplier;
-                    } else {
-                        $selectedPosts[$postOfTag->getUid()] += $tagMultiplier;
+                        if (!array_key_exists($postOfTag->getUid(), $selectedPosts)) {
+                            $selectedPosts[$postOfTag->getUid()] = $tagMultiplier;
+                        } else {
+                            $selectedPosts[$postOfTag->getUid()] += $tagMultiplier;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
If you set the tag multiplier to 0 it currently still searches posts with the same tags. Since this is called multiplier I'd expect it to ignore the tags if it is set to zero.