### PR TITLE
Fixed invalid regex syntax causing crash on Typo3 10.4.4

### DIFF
--- a/Configuration/Routes/BlogArchive.yaml
+++ b/Configuration/Routes/BlogArchive.yaml
@@ -30,7 +30,7 @@ routeEnhancers:
           page: '@widget_0/currentPage'
     defaultController: 'Post::listPostsByDate'
     requirements:
-      year: '[0-9]{1..4}'
+      year: '[0-9]{1,4}'
       month: '[a-z]+'
       page: '\d+'
     aspects:


### PR DESCRIPTION
Error message was:

Parameter "tx_blog_archive__year" for route "tx_blog_archive_1" must match "[0-9]{1..4}" ("2020" given) to generate a corresponding URL.

Regex quantifiers are separated by comma, this pull request fixes the issue.