### PR TITLE
Prevent duplicate parts/names in URLs 

### DIFF
--- a/Configuration/Routes/BlogArchive.yaml
+++ b/Configuration/Routes/BlogArchive.yaml
@@ -5,24 +5,24 @@ routeEnhancers:
     plugin: Archive
     routes:
       -
-        routePath: '/archive/{year}'
+        routePath: '/{year}'
         _controller: 'Post::listPostsByDate'
         _arguments:
           year: year
       -
-        routePath: '/archive/{year}/page-{page}'
+        routePath: '/{year}/page-{page}'
         _controller: 'Post::listPostsByDate'
         _arguments:
           year: year
           page: '@widget_0/currentPage'
       -
-        routePath: '/archive/{year}/{month}'
+        routePath: '/{year}/{month}'
         _controller: 'Post::listPostsByDate'
         _arguments:
           year: year
           month: month
       -
-        routePath: '/archive/{year}/{month}/page-{page}'
+        routePath: '/{year}/{month}/page-{page}'
         _controller: 'Post::listPostsByDate'
         _arguments:
           year: year

--- a/Configuration/Routes/BlogAuthorPosts.yaml
+++ b/Configuration/Routes/BlogAuthorPosts.yaml
@@ -5,12 +5,12 @@ routeEnhancers:
     plugin: AuthorPosts
     routes:
       -
-        routePath: '/author/{author_title}'
+        routePath: '/{author_title}'
         _controller: 'Post::listPostsByAuthor'
         _arguments:
           author_title: author
       -
-        routePath: '/author/{author_title}/page-{page}'
+        routePath: '/{author_title}/page-{page}'
         _controller: 'Post::listPostsByAuthor'
         _arguments:
           author_title: author

--- a/Configuration/Routes/BlogCategory.yaml
+++ b/Configuration/Routes/BlogCategory.yaml
@@ -5,12 +5,12 @@ routeEnhancers:
     plugin: Category
     routes:
       -
-        routePath: '/category/{category_title}'
+        routePath: '/{category_title}'
         _controller: 'Post::listPostsByCategory'
         _arguments:
           category_title: category
       -
-        routePath: '/category/{category_title}/page-{page}'
+        routePath: '/{category_title}/page-{page}'
         _controller: 'Post::listPostsByCategory'
         _arguments:
           category_title: category

--- a/Configuration/Routes/BlogTag.yaml
+++ b/Configuration/Routes/BlogTag.yaml
@@ -5,12 +5,12 @@ routeEnhancers:
     plugin: Tag
     routes:
       -
-        routePath: '/tag/{tag_title}'
+        routePath: '/{tag_title}'
         _controller: 'Post::listPostsByTag'
         _arguments:
           tag_title: tag
       -
-        routePath: '/tag/{tag_title}/page-{page}'
+        routePath: '/{tag_title}/page-{page}'
         _controller: 'Post::listPostsByTag'
         _arguments:
           tag_title: tag


### PR DESCRIPTION
Please bear with me if I get this wrong, but as far as my understanding of this extension goes, there are different plugins to show blog posts for a certain author, tag, category and year (archive).

This means, that each plugin is supposed to go on a separate page. This is exactly what the automatic setup does.

So, because we are already on a page named "Archive", "Category", "Tag" or "Author", the route enhancer should not add this piece of information again, as this gives us URLs like
https://example.domian/blog/tag/tag/exampletag or
https://example.domian/blog/archive/archive/2020/may

At least that's what happens on the website I'm currently developing.

It makes sense for extensions like news, where there's a single plugin on a single page that fits all.

If my logic so far is correct, and I'm not missing some use-cases, this pull request removes the redundant URL parts from the route enhancer configuration.