### PR TITLE
[BUGFIX] Cast pageUid in RedirectFinisher to string

### DIFF
--- a/Classes/Domain/Factory/CommentFormFactory.php
+++ b/Classes/Domain/Factory/CommentFormFactory.php
@@ -98,7 +98,7 @@ class CommentFormFactory extends AbstractFormFactory
         $form->addFinisher($commentFinisher);
 
         $redirectFinisher = $objectManager->get(RedirectFinisher::class);
-        $redirectFinisher->setOption('pageUid', $this->getTypoScriptFrontendController()->id);
+        $redirectFinisher->setOption('pageUid', (string)$this->getTypoScriptFrontendController()->id);
         $form->addFinisher($redirectFinisher);
 
         $this->triggerFormBuildingFinished($form);


### PR DESCRIPTION
Due to an undiscovered breaking change, redirects in the RedirectFinisher
don't work anymore if the pageUid is an integer. This change casts the
pageUid to a string to workaround this new behavior.

See https://review.typo3.org/c/Packages/TYPO3.CMS/+/65467 as well.