### PR TITLE
[BUGFIX] Enforce ArchiveViewHelper to return a string

### DIFF
--- a/Classes/ViewHelpers/Link/ArchiveViewHelper.php
+++ b/Classes/ViewHelpers/Link/ArchiveViewHelper.php
@@ -70,7 +70,7 @@ class ArchiveViewHelper extends AbstractTagBasedViewHelper
             $result = $this->renderChildren();
         }
 
-        return $result;
+        return (string)$result;
     }
 
     /**


### PR DESCRIPTION
If the configuration `plugin.tx_blog.settings.archiveUid` is undefined,
the link to the archive pages cannot be built which causes the
"generation" of the link text only. However, this may fail if only the
year is returned, as it is an integer.

This patch adds a string cast to the rendering result to handle
year-only results as strings as well.