### PR TITLE
[BUGFIX] Setup mysql server in docker container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,21 +12,28 @@ jobs:
       matrix:
         typo3: [ ^10.4, ^11.0 ]
         php: [ '7.4' ]
+        mysql: ['5.7']
         include:
           - typo3: ^10.4
             php: '7.4'
+            mysql: '5.7'
             coverage: true
           - typo3: ^10.4
             php: '7.2'
+            mysql: '5.7'
           - typo3: ^10.4
             php: '7.3'
+            mysql: '5.7'
 
     steps:
-      - name: Start database server
-        run: sudo /etc/init.d/mysql start
-
       - name: Checkout Code
         uses: actions/checkout@v2
+
+      - name: Set up MySQL ${{ matrix.mysql }}
+        uses: mirromutth/mysql-action@v1.1
+        with:
+          mysql version: ${{ matrix.mysql }}
+          mysql root password: 'root'
 
       - name: Set up PHP version ${{ matrix.php }}
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
GitHub boots MySQL v8 in the latest Ubuntu image which is unsupported
with TYPO3 v10 and PHP < 7.4. Due to this, we enforce using MySQL 5.7
in CI for now.

Releases: master, 10