### PR TITLE
[BUGFIX] Fix uid_local out of range error when using workspaces

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -145,10 +145,10 @@ CREATE TABLE tx_blog_domain_model_author (
 # Table structure for table 'tx_blog_post_author_mm'
 #
 CREATE TABLE tx_blog_post_author_mm (
-  uid_local int(11) unsigned DEFAULT '0' NOT NULL,
-  uid_foreign int(11) unsigned DEFAULT '0' NOT NULL,
-  sorting int(11) unsigned DEFAULT '0' NOT NULL,
-  sorting_foreign int(11) unsigned DEFAULT '0' NOT NULL,
+  uid_local int(11) DEFAULT '0' NOT NULL,
+  uid_foreign int(11) DEFAULT '0' NOT NULL,
+  sorting int(11) DEFAULT '0' NOT NULL,
+  sorting_foreign int(11) DEFAULT '0' NOT NULL,
   KEY uid_local (uid_local),
   KEY uid_foreign (uid_foreign)
 );


### PR DESCRIPTION
We get the following error using workspaces together with `EXT:blog` when we try to publish a blog post:

```
An exception occurred while executing 'UPDATE `tx_blog_post_author_mm` SET `uid_local` = ? WHERE `uid_local` = ?' with params [-2541, 2541]: Out of range value for column 'uid_local' at row 1
```

The problem seems to be that the column `uid_local` does only allow unsigned integers, the workspace extension however tries to set it to a negative value. To fix this I simply used the column definitions from `tx_blog_tag_pages_mm`.