### PR TITLE
Feat/add custom rss feed configuration

### DIFF
--- a/Classes/Controller/PostController.php
+++ b/Classes/Controller/PostController.php
@@ -117,26 +117,26 @@ class PostController extends ActionController
     {
         parent::initializeView($view);
         if ($this->request->getFormat() === 'rss') {
-            $action = '.' . $this->request->getControllerActionName();
+            $action = $this->request->getControllerActionName();
             $arguments = [];
             switch ($action) {
-                case '.listPostsByCategory':
+                case 'listPostsByCategory':
                     if (isset($this->arguments['category'])) {
                         $arguments[] = $this->arguments['category']->getValue()->getTitle();
                     }
                     break;
-                case '.listPostsByDate':
+                case 'listPostsByDate':
                     $arguments[] = (int)$this->arguments['year']->getValue();
                     if (isset($this->arguments['month'])) {
                         $arguments[] = (int)$this->arguments['month']->getValue();
                     }
                     break;
-                case '.listPostsByTag':
+                case 'listPostsByTag':
                     if (isset($this->arguments['tag'])) {
                         $arguments[] = $this->arguments['tag']->getValue()->getTitle();
                     }
                     break;
-                case '.listPostsByAuthor':
+                case 'listPostsByAuthor':
                     if (isset($this->arguments['author'])) {
                         $arguments[] = $this->arguments['author']->getValue()->getName();
                     }
@@ -145,8 +145,8 @@ class PostController extends ActionController
             }
 
             $feedData = [
-                'title' => LocalizationUtility::translate('feed.title' . $action, 'blog', $arguments),
-                'description' => LocalizationUtility::translate('feed.description' . $action, 'blog', $arguments),
+                'title' => LocalizationUtility::translate('feed.title.' . $action, 'blog', $arguments),
+                'description' => LocalizationUtility::translate('feed.description.' . $action, 'blog', $arguments),
                 'language' => $this->getSiteLanguage()->getTwoLetterIsoCode(),
                 'link' => $this->getRequestUrl(),
                 'date' => date('r'),

--- a/Classes/Controller/PostController.php
+++ b/Classes/Controller/PostController.php
@@ -141,7 +141,9 @@ class PostController extends ActionController
                         $arguments[] = $this->arguments['author']->getValue()->getName();
                     }
                     break;
-                default:
+                case ([] !== ($this->settings['demand'] ?? [])):
+                    $this->actionMethodName = 'listByDemandAction';
+                    break;
             }
 
             $feedData = [
@@ -185,19 +187,22 @@ class PostController extends ActionController
      * @throws \TYPO3\CMS\Extbase\Configuration\Exception\InvalidConfigurationTypeException
      * @throws \TYPO3\CMS\Extbase\Persistence\Exception\InvalidQueryException
      */
-    public function listByDemandAction(): ResponseInterface
+    public function listByDemandAction(int $currentPage = 1): ResponseInterface
     {
         $repositoryDemand = $this->postRepositoryDemandFactory->createFromSettings($this->settings['demand'] ?? []);
         $posts = $this->postRepository->findByRepositoryDemand($repositoryDemand);
 
         if ([] !== $repositoryDemand->getPosts()) {
             $posts = $this->sortPostsByManualOrder($posts, $repositoryDemand->getPosts());
+            $pagination = [];
+        } else {
+            $pagination = $this->getPagination($posts, $currentPage);
         }
 
         $this->view->assign('type', 'demand');
         $this->view->assign('demand', $repositoryDemand);
         $this->view->assign('posts', $posts);
-        $this->view->assign('pagination', []);
+        $this->view->assign('pagination', $pagination);
 
         return $this->htmlResponse();
     }

--- a/Classes/Controller/PostController.php
+++ b/Classes/Controller/PostController.php
@@ -476,10 +476,7 @@ class PostController extends ActionController
     protected function getPagination(QueryResultInterface $objects, int $currentPage = 1): ?BlogPagination
     {
         $maximumNumberOfLinks = (int) ($this->settings['lists']['pagination']['maximumNumberOfLinks'] ?? 0);
-        $itemsPerPage = 10;
-        if ($this->request->getFormat() === 'html') {
-            $itemsPerPage = (int) ($this->settings['lists']['pagination']['itemsPerPage'] ?? 10);
-        }
+        $itemsPerPage = (int) ($this->settings['lists']['pagination']['itemsPerPage'] ?? 10);
 
         $paginator = new QueryResultPaginator($objects, $currentPage, $itemsPerPage);
         return new BlogPagination($paginator, $maximumNumberOfLinks);

--- a/Classes/Domain/Repository/PostRepository.php
+++ b/Classes/Domain/Repository/PostRepository.php
@@ -73,9 +73,10 @@ class PostRepository extends Repository
 
     /**
      * @param PostRepositoryDemand $repositoryDemand;
-     * @return Post[]
+     *
+     * @return Post[]|\TYPO3\CMS\Extbase\Persistence\QueryResultInterface
      */
-    public function findByRepositoryDemand(PostRepositoryDemand $repositoryDemand): array
+    public function findByRepositoryDemand(PostRepositoryDemand $repositoryDemand)
     {
         $query = $this->createQuery();
 
@@ -113,21 +114,7 @@ class PostRepository extends Repository
             $query->setLimit($limit);
         }
 
-        /** @var Post[] $result */
-        $result = $query->execute()->toArray();
-
-        if ($repositoryDemand->getPosts() !== []) {
-            // Sort manually selected posts by defined order in group field
-            $sortedPosts = array_flip($repositoryDemand->getPosts());
-            foreach ($result as $post) {
-                $sortedPosts[$post->getUid()] = $post;
-            }
-            $result = array_values(array_filter($sortedPosts, function ($value) {
-                return $value instanceof Post;
-            }));
-        }
-
-        return $result;
+        return $query->execute();
     }
 
     /**

--- a/Classes/Factory/PostRepositoryDemandFactory.php
+++ b/Classes/Factory/PostRepositoryDemandFactory.php
@@ -57,7 +57,10 @@ class PostRepositoryDemandFactory
             $demand->setTagsConjunction($settings['tagsConjunction']);
         }
 
-        if (isset($GLOBALS['TCA']['pages']['columns'][$settings['sortBy']])) {
+        if ('' !== ($settings['ordering'] ?? null)) {
+            $ordering = explode(' ', $settings['ordering']);
+            $demand->setOrdering($ordering[0], $ordering[1] ?? 'ASC');
+        } else if (isset($GLOBALS['TCA']['pages']['columns'][$settings['sortBy']])) {
             $direction = strtoupper($settings['sortDirection'] ?? 'ASC');
             if (!in_array($direction, ['ASC', 'DESC'], true)) {
                 $direction = 'ASC';

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -1683,3 +1683,20 @@ plugin.tx_blog.settings.meta.listfooter.elements.comments.enable
    Description
      **Show comments in the meta section:**
 
+TYPO3 Blog: RSS Feed
+--------------------
+
+Custom configuration
+^^^^^^^^^^^^^^^^^^^^
+
+You can modify the rss feed configuration by setting the `PostRepositoryDemand` DTO via TypoScript for the rss feed pagetype
+
+.. code-block:: typoscript
+
+[getTSFE().type == 200]
+    plugin.tx_blog.settings.demand {
+        categories = 15,153,158,151,16,87,251,88,18,22,89,19
+        categoriesConjunction = OR
+        ordering = publish_date DESC
+    }
+[end]


### PR DESCRIPTION
Allow custom rss feed configuration by using `listByDemandAction` in the PostController if settings are set (via Typoscript).

E.g. via

```typoscript
[getTSFE().type == 200]
    plugin.tx_blog.settings.demand {
        categories = 15,153,158,151,16,87,251,88,18,22,89,19
        categoriesConjunction = OR
        ordering = publish_date DESC
    }
[end]
``` 