### PR TITLE
[BUGFIX] Exclude various dev-only files from dist archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,10 +9,13 @@
 .editorconfig export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
+.php-cs-fixer.dist.php export-ignore
+.phplint.yml export-ignore
 .travis.yaml export-ignore
 
 # Build
 package.json export-ignore
+postcss.config.js export-ignore
 webpack.config.js export-ignore
 yarn.lock export-ignore
 


### PR DESCRIPTION
This PR extends `.gitattributes` by the following files to exclude them from dist archives:

* `.php-cs-fixer.dist.php`
* `.phplint.yml`
* `postcss.config.js`