### PR TITLE
fix: Article publish date is always replaced by current timestamp

### DIFF
--- a/Classes/Hooks/DataHandlerHook.php
+++ b/Classes/Hooks/DataHandlerHook.php
@@ -40,14 +40,14 @@ class DataHandlerHook
             $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
                 ->getQueryBuilderForTable($table);
             $queryBuilder->getRestrictions()->removeAll();
-            $record = $queryBuilder
-                ->select('*')
+            $publishDate = $queryBuilder
+                ->select('publish_date')
                 ->from($table)
                 ->where($queryBuilder->expr()->eq('uid', (int)$id))
                 ->executeQuery()
                 ->fetchOne();
-            if (isset($record)) {
-                $timestamp = (int) (($record['publish_date'] ?? 0) !== 0 ? $record['publish_date'] : time());
+            if ($publishDate !== false) {
+                $timestamp = (int) ($publishDate !== 0 ? $publishDate : time());
                 $queryBuilder
                     ->update($table)
                     ->set('publish_date', $timestamp)

--- a/Tests/Functional/Hooks/DataHandlerHookTest.php
+++ b/Tests/Functional/Hooks/DataHandlerHookTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the package t3g/blog.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace T3G\AgencyPack\Blog\Tests\Functional\Service;
+
+use T3G\AgencyPack\Blog\Constants;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Core\Bootstrap;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+final class DataHandlerHookTest extends FunctionalTestCase
+{
+    protected array $testExtensionsToLoad = [
+        'typo3conf/ext/blog'
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importCSVDataSet(__DIR__ . '/../Fixtures/DataHandler/be_users.csv');
+        $this->setUpBackendUser(1);
+        Bootstrap::initializeLanguageObject();
+    }
+
+    /**
+     * @test
+     */
+    public function create(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/BlogBasePages.csv');
+
+        $data = [
+            'pages' => [
+                'NEW_blogPost1' => [
+                    'pid' => 2,
+                    'hidden' => 0,
+                    'title' => 'Post 1',
+                    'doktype' => Constants::DOKTYPE_BLOG_POST,
+                    'publish_date' => 1689811200,
+                    'crdate_month' => 0,
+                    'crdate_year' => 0,
+                ],
+                'NEW_blogPage1' => [
+                    'pid' => 1,
+                    'hidden' => 0,
+                    'title' => 'Page 1',
+                    'doktype' => Constants::DOKTYPE_BLOG_PAGE,
+                    'publish_date' => 1689811200,
+                    'crdate_month' => 0,
+                    'crdate_year' => 0,
+                ]
+            ]
+        ];
+
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->start($data, []);
+        $dataHandler->process_datamap();
+
+        /** @var array $post */
+        $post = BackendUtility::getRecord('pages', 3);
+        self::assertEquals($post['title'], 'Post 1');
+        self::assertEquals($post['doktype'], Constants::DOKTYPE_BLOG_POST);
+        self::assertEquals($post['crdate_month'], 7);
+        self::assertEquals($post['crdate_year'], 2023);
+
+        /** @var array $page */
+        $page = BackendUtility::getRecord('pages', 4);
+        self::assertEquals($page['title'], 'Page 1');
+        self::assertEquals($page['doktype'], Constants::DOKTYPE_BLOG_PAGE);
+        self::assertEquals($page['crdate_month'], 7);
+        self::assertEquals($page['crdate_year'], 2023);
+    }
+
+    /**
+     * @test
+     */
+    public function update(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/BlogBasePages.csv');
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+
+        // Initial
+        $initial = [
+            'pages' => [
+                'NEW_blogPost1' => [
+                    'pid' => 2,
+                    'hidden' => 0,
+                    'title' => 'Post 1',
+                    'doktype' => Constants::DOKTYPE_BLOG_POST,
+                    'publish_date' => 1689811200,
+                    'crdate_month' => 0,
+                    'crdate_year' => 0,
+                ],
+            ]
+        ];
+        $dataHandler->start($initial, []);
+        $dataHandler->process_datamap();
+
+        /** @var array $initialRecord */
+        $initialRecord = BackendUtility::getRecord('pages', 3);
+        self::assertEquals($initialRecord['title'], 'Post 1');
+        self::assertEquals($initialRecord['doktype'], Constants::DOKTYPE_BLOG_POST);
+        self::assertEquals($initialRecord['crdate_month'], 7);
+        self::assertEquals($initialRecord['crdate_year'], 2023);
+
+        // Update
+        $update = [
+            'pages' => [
+                3 => [
+                    'publish_date' => 1653004800,
+                ],
+            ]
+        ];
+        $dataHandler->start($update, []);
+        $dataHandler->process_datamap();
+
+        /** @var array $updateRecord */
+        $updateRecord = BackendUtility::getRecord('pages', 3);
+        self::assertEquals($updateRecord['title'], 'Post 1');
+        self::assertEquals($updateRecord['doktype'], Constants::DOKTYPE_BLOG_POST);
+        self::assertEquals($updateRecord['crdate_month'], 5);
+        self::assertEquals($updateRecord['crdate_year'], 2022);
+    }
+}

--- a/Tests/Functional/Hooks/Fixtures/BlogBasePages.csv
+++ b/Tests/Functional/Hooks/Fixtures/BlogBasePages.csv
@@ -1,0 +1,9 @@
+"pages",,,,,,,,
+,uid,pid,crdate,doktype,title,is_siteroot,module,TSconfig
+,1,0,1683627000,138,Blog,1,,"TCEFORM.pages.tags.PAGE_TSCONFIG_ID = 2
+TCEFORM.pages.authors.PAGE_TSCONFIG_ID = 2
+TCEFORM.pages.categories.PAGE_TSCONFIG_ID = 2
+TCEFORM.tt_content.pi_flexform.blog_demandedposts.sDEF.settings\.demand\.authors.PAGE_TSCONFIG_ID = 2
+TCEFORM.tt_content.pi_flexform.blog_demandedposts.sDEF.settings\.demand\.tags.PAGE_TSCONFIG_ID = 2
+TCEFORM.tt_content.pi_flexform.blog_demandedposts.sDEF.settings\.demand\.categories.PAGE_TSCONFIG_ID = 2"
+,2,1,1683627001,254,Data,0,blog,


### PR DESCRIPTION
Fixes #281

**Explanation:**

In https://github.com/TYPO3GmbH/blog/commit/b77f22dea9a3db4f2d554a23c912089e33ca8f75#diff-62c740cd7ba615b9771602fedd2cab6bc50ac4052c3f8432913f59dbaf3d5effR48 an attempted migration away from the deprecated DBAL `fetch()` method failed. 
Instead of the drop-in replacement `fetchAssociative`, the wrong method `fetchOne` was chosen. 
Maybe the author @benjaminkott had intended to use `fetchOne`, but select the desired field rather than the entire row. (The latter approach is taken by this PR.)

In `v12.0.0` (or at any time after b77f22dea9a3db4f2d554a23c912089e33ca8f75), the database loaded and transmitted the entire row, but only the first column of the first row was returned. (See `Doctrine\DBAL\ForwardCompatibility\Result::fetchOne`, which calls `fetchNumeric` internally.)

Note that loading and transmitting the entire database row (`SELECT *`) is wasteful and slow. 

Therefore, instead of fixing the issue by using `fetchAssociative`, this PR fixes the issue by keeping `fetchOne` but selecting only the used field (`'publish_date'`).

If no row is found, `fetchOne` will return `false`. A strictly typed check for `false` is performed before comparing (again, strictly) to `0`, in which case the current time will be used.