### PR TITLE
Add missing equals expression when building query in StaticDatabaseMapper

### DIFF
--- a/Classes/Routing/Aspect/StaticDatabaseMapper.php
+++ b/Classes/Routing/Aspect/StaticDatabaseMapper.php
@@ -100,7 +100,7 @@ class StaticDatabaseMapper implements StaticMappableAspectInterface, \Countable
 
         if (count($this->where) > 0) {
             foreach ($this->where as $key => $value) {
-                $queryBuilder->andWhere($key, $queryBuilder->createNamedParameter($value));
+                $queryBuilder->andWhere($queryBuilder->expr()->eq($key, $queryBuilder->createNamedParameter($value)));
             }
         }
 


### PR DESCRIPTION
The query in the StaticDatabaseMapper is not constructed correctly since no equals expression is used when adding the where conditions.

This PR adds that missing equals expression. Fixes #249.