### PR TITLE
[BUGFIX] Fix storagePid problem in PostRepository

### DIFF
--- a/Classes/Domain/Repository/PostRepository.php
+++ b/Classes/Domain/Repository/PostRepository.php
@@ -40,7 +40,6 @@ class PostRepository extends Repository
     public function initializeObject(): void
     {
         $configurationManager = GeneralUtility::makeInstance(ConfigurationManagerInterface::class);
-        $this->settings = $configurationManager->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK, 'blog');
 
         $querySettings = GeneralUtility::makeInstance(
             Typo3QuerySettings::class,
@@ -414,7 +413,10 @@ class PostRepository extends Repository
 
     protected function getStoragePidsFromTypoScript(): array
     {
-        return GeneralUtility::intExplode(',', $this->settings['persistence']['storagePid']);
+        $configurationManager = GeneralUtility::makeInstance(ConfigurationManagerInterface::class);
+        $settings = $configurationManager->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK);
+
+        return GeneralUtility::intExplode(',', $settings['persistence']['storagePid']);
     }
 
     /**


### PR DESCRIPTION
This patch fixes a problem with ignored storagePid if there are multiple blog post plugins on the same page. Only the storagePid setting from the first plugin was evaluated.

Fixes #292