### PR TITLE
[BUGFIX] ignore pages.l18n_cfg of translated posts when searching for translations

### DIFF
--- a/Classes/Domain/Repository/PostRepository.php
+++ b/Classes/Domain/Repository/PostRepository.php
@@ -57,8 +57,6 @@ class PostRepository extends Repository
                 $query->equals('l18n_cfg', 0),
                 $query->equals('l18n_cfg', 2)
             );
-        } else {
-            $this->defaultConstraints[] = $query->lessThan('l18n_cfg', 2);
         }
 
         $this->defaultOrderings = [
@@ -270,7 +268,9 @@ class PostRepository extends Repository
     protected function getPostWithLanguage(int $pageId, int $languageId): ?Post
     {
         $query = $this->createQuery();
-        $constraints = $this->defaultConstraints;
+        $constraints = [
+            $query->equals('doktype', Constants::DOKTYPE_BLOG_POST)
+        ];
 
         if ($languageId > 0) {
             $constraints[] = $query->equals('l10n_parent', $pageId);

--- a/Classes/Domain/Repository/TagRepository.php
+++ b/Classes/Domain/Repository/TagRepository.php
@@ -35,7 +35,10 @@ class TagRepository extends Repository
     {
         $query = $this->createQuery();
         $query->matching(
-            $query->in('uid', $uids)
+            $query->logicalOr([
+                $query->in('uid', $uids),
+                $query->in('l18n_parent', $uids)
+            ])
         );
 
         return $query->execute();


### PR DESCRIPTION
When creating new translation, TYPO3 sets this field to the same value as the translation source, so nothing can be found for pages.l18n_cfg == 2 ("Hide page if no translation for current language exists").