### PR TITLE
Fix category parent getter to handle lazy loading proxy objects

### DIFF
--- a/Classes/Domain/Model/Category.php
+++ b/Classes/Domain/Model/Category.php
@@ -88,6 +88,9 @@ class Category extends AbstractEntity
 
     public function getParent(): ?self
     {
+        if ($this->parent instanceof LazyLoadingProxy) {
+            $this->parent->_loadRealInstance();
+        }
         return $this->parent;
     }
 

--- a/Classes/Domain/Model/Category.php
+++ b/Classes/Domain/Model/Category.php
@@ -13,6 +13,7 @@ namespace T3G\AgencyPack\Blog\Domain\Model;
 use T3G\AgencyPack\Blog\Constants;
 use TYPO3\CMS\Extbase\Annotation as Extbase;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+use TYPO3\CMS\Extbase\Persistence\Generic\LazyLoadingProxy;
 use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 
 class Category extends AbstractEntity


### PR DESCRIPTION
Fix category parent getter to handle lazy loading proxy objects

As done in TYPO3 core (vendor/typo3/cms-extbase/Classes/Domain/Model/Category.php)

Fixes #302 