### PR TITLE
Normalize category storage PID on TYPO3v12

### DIFF
--- a/Classes/Domain/Repository/CategoryRepository.php
+++ b/Classes/Domain/Repository/CategoryRepository.php
@@ -33,7 +33,7 @@ class CategoryRepository extends Repository
             GeneralUtility::makeInstance(Context::class),
             $configurationManager
         );
-        $querySettings->setStoragePageIds(GeneralUtility::intExplode(',', $this->settings['persistence']['storagePid']));
+        $querySettings->setStoragePageIds(GeneralUtility::intExplode(',', (string)$this->settings['persistence']['storagePid']));
         $this->setDefaultQuerySettings($querySettings);
 
         $this->defaultOrderings = [

--- a/Classes/Domain/Repository/PostRepository.php
+++ b/Classes/Domain/Repository/PostRepository.php
@@ -414,7 +414,7 @@ class PostRepository extends Repository
 
     protected function getStoragePidsFromTypoScript(): array
     {
-        return GeneralUtility::intExplode(',', $this->settings['persistence']['storagePid']);
+        return GeneralUtility::intExplode(',', (string)$this->settings['persistence']['storagePid']);
     }
 
     /**

--- a/Classes/Domain/Repository/TagRepository.php
+++ b/Classes/Domain/Repository/TagRepository.php
@@ -57,7 +57,7 @@ class TagRepository extends Repository
         // limitation to storage pid for multi domain purpose
         if ($this->settings['persistence']['storagePid']) {
             // force storage pids as integer
-            $storagePids = GeneralUtility::intExplode(',', $this->settings['persistence']['storagePid']);
+            $storagePids = GeneralUtility::intExplode(',', (string)$this->settings['persistence']['storagePid']);
             $queryBuilder->where('t.pid IN(' . implode(',', $storagePids) . ')');
         }
 


### PR DESCRIPTION
The new TypoScript parser introduced in TYPO3v12 yields a regular integer in case of a single storagePid. Only in case of a CSV this will be a string. This in turn leads to explode() failing with a type error in the integer case.

Fix this by normalizing the setting value to string.

Fixes: #301