### PR TITLE
[BUGFIX] Add fallback to TypoScript settings in ViewHelpers

### DIFF
--- a/Classes/ViewHelpers/Link/ArchiveViewHelper.php
+++ b/Classes/ViewHelpers/Link/ArchiveViewHelper.php
@@ -43,7 +43,14 @@ class ArchiveViewHelper extends AbstractTagBasedViewHelper
             ->getAttribute('site')
             ->getSettings()
             ->get('plugin.tx_blog.settings.archiveUid') ?? 0;
-
+        if ($pageUid === 0) {
+            $pageUid = (int)($request->getAttribute('frontend.typoscript')->getSetupTree()
+                ->getChildByName('plugin')
+                ?->getChildByName('tx_blog')
+                ?->getChildByName('settings')
+                ?->getChildByName('archiveUid')
+                ?->getValue() ?? 0);
+        }
         $rssTypeNum = (int)(
             $request->getAttribute('frontend.typoscript')->getSetupTree()
             ->getChildByName('blog_rss_archive')

--- a/Classes/ViewHelpers/Link/AuthorViewHelper.php
+++ b/Classes/ViewHelpers/Link/AuthorViewHelper.php
@@ -59,6 +59,14 @@ class AuthorViewHelper extends AbstractTagBasedViewHelper
             ->getAttribute('site')
             ->getSettings()
             ->get('plugin.tx_blog.settings.authorUid') ?? 0;
+        if ($pageUid === 0) {
+            $pageUid = (int)($request->getAttribute('frontend.typoscript')->getSetupTree()
+                ->getChildByName('plugin')
+                ?->getChildByName('tx_blog')
+                ?->getChildByName('settings')
+                ?->getChildByName('authorUid')
+                ?->getValue() ?? 0);
+        }
         $uriBuilder = $this->getUriBuilder($pageUid, [], $rssFormat);
         $arguments = [
             'author' => $author->getUid(),

--- a/Classes/ViewHelpers/Link/CategoryViewHelper.php
+++ b/Classes/ViewHelpers/Link/CategoryViewHelper.php
@@ -44,6 +44,14 @@ class CategoryViewHelper extends AbstractTagBasedViewHelper
             ->getAttribute('site')
             ->getSettings()
             ->get('plugin.tx_blog.settings.categoryUid') ?? 0;
+        if ($pageUid === 0) {
+            $pageUid = (int)($request->getAttribute('frontend.typoscript')->getSetupTree()
+                ->getChildByName('plugin')
+                ?->getChildByName('tx_blog')
+                ?->getChildByName('settings')
+                ?->getChildByName('categoryUid')
+                ?->getValue() ?? 0);
+        }
         $arguments = [
             'category' => $category->getUid(),
         ];

--- a/Classes/ViewHelpers/Link/TagViewHelper.php
+++ b/Classes/ViewHelpers/Link/TagViewHelper.php
@@ -44,6 +44,14 @@ class TagViewHelper extends AbstractTagBasedViewHelper
             ->getAttribute('site')
             ->getSettings()
             ->get('plugin.tx_blog.settings.tagUid') ?? 0;
+        if ($pageUid === 0) {
+            $pageUid = (int)($request->getAttribute('frontend.typoscript')->getSetupTree()
+                ->getChildByName('plugin')
+                ?->getChildByName('tx_blog')
+                ?->getChildByName('settings')
+                ?->getChildByName('tagUid')
+                ?->getValue() ?? 0);
+        }
         $arguments = [
             'tag' => $tag->getUid(),
         ];


### PR DESCRIPTION
This PR addresses https://github.com/TYPO3GmbH/blog/issues/339 and respects detail page ids from TypoScript if not defined in Site Settings, re-enabling the option to have different detail pages configured in a single site using TypoScript conditions.
