### PR TITLE
[FEATURE] Add dedicated RSS settings

### DIFF
--- a/Classes/Controller/PostController.php
+++ b/Classes/Controller/PostController.php
@@ -92,8 +92,8 @@ class PostController extends ActionController
             }
 
             $feedData = [
-                'title' => LocalizationUtility::translate('feed.title' . $action, 'blog', $arguments),
-                'description' => LocalizationUtility::translate('feed.description' . $action, 'blog', $arguments),
+                'title' => ($this->settings['rss']['title'] ?? false) ?: LocalizationUtility::translate('feed.title' . $action, 'blog', $arguments),
+                'description' => ($this->settings['rss']['description'] ?? false) ?: LocalizationUtility::translate('feed.description' . $action, 'blog', $arguments),
                 'language' => $this->getSiteLanguage()->getLocale()->getLanguageCode(),
                 'link' => $this->getRequestUrl(),
                 'date' => date('r'),
@@ -110,15 +110,21 @@ class PostController extends ActionController
      */
     public function listRecentPostsAction(int $currentPage = 1): ResponseInterface
     {
-        $maximumItems = (int) ($this->settings['lists']['posts']['maximumDisplayedItems'] ?? 0);
+        if ($this->request->getFormat() === 'rss') {
+            $maximumItems = (int) ($this->settings['rss']['maximumDisplayedItems'] ?? 10);
+        } else {
+            $maximumItems = (int) ($this->settings['lists']['posts']['maximumDisplayedItems'] ?? 0);
+        }
         $posts = (0 === $maximumItems)
             ? $this->postRepository->findAll()
             : $this->postRepository->findAllWithLimit($maximumItems);
-        $pagination = $this->getPagination($posts, $currentPage);
+        if ($this->request->getFormat() !== 'rss') {
+            $pagination = $this->getPagination($posts, $currentPage);
+        }
 
         $this->view->assign('type', 'recent');
         $this->view->assign('posts', $posts);
-        $this->view->assign('pagination', $pagination);
+        $this->view->assign('pagination', $pagination ?? null);
         return $this->htmlResponse();
     }
 
@@ -141,7 +147,11 @@ class PostController extends ActionController
      */
     public function listLatestPostsAction(): ResponseInterface
     {
-        $maximumItems = (int) ($this->settings['latestPosts']['limit'] ?? 3);
+        if ($this->request->getFormat() === 'rss') {
+            $maximumItems = (int) ($this->settings['rss']['maximumDisplayedItems'] ?? 10);
+        } else {
+            $maximumItems = (int) ($this->settings['latestPosts']['limit'] ?? 3);
+        }
         $posts = $this->postRepository->findAllWithLimit($maximumItems);
 
         $this->view->assign('type', 'latest');
@@ -156,14 +166,19 @@ class PostController extends ActionController
             $this->view->assign('archiveData', ArchiveUtility::extractDataFromPosts($posts));
         } else {
             $dateTime = new \DateTimeImmutable(sprintf('%d-%d-1', $year, $month ?? 1));
-            $posts = $this->postRepository->findByMonthAndYear($year, $month);
-            $pagination = $this->getPagination($posts, $currentPage);
+            if ($this->request->getFormat() === 'rss') {
+                $maximumItems = (int) ($this->settings['rss']['maximumDisplayedItems'] ?? 10);
+            }
+            $posts = $this->postRepository->findByMonthAndYearWithLimit($year, $month, $maximumItems ?? 0);
+            if ($this->request->getFormat() !== 'rss') {
+                $pagination = $this->getPagination($posts, $currentPage);
+            }
             $this->view->assign('type', 'bydate');
             $this->view->assign('month', $month);
             $this->view->assign('year', $year);
             $this->view->assign('timestamp', $dateTime->getTimestamp());
             $this->view->assign('posts', $posts);
-            $this->view->assign('pagination', $pagination);
+            $this->view->assign('pagination', $pagination ?? null);
             $title = str_replace([
                 '###MONTH###',
                 '###MONTH_NAME###',
@@ -197,11 +212,16 @@ class PostController extends ActionController
         }
 
         if ($category !== null) {
-            $posts = $this->postRepository->findAllByCategory($category);
-            $pagination = $this->getPagination($posts, $currentPage);
+            if ($this->request->getFormat() === 'rss') {
+                $maximumItems = (int) ($this->settings['rss']['maximumDisplayedItems'] ?? 10);
+            }
+            $posts = $this->postRepository->findAllByCategoryWithLimit($category, $maximumItems ?? 0);
+            if ($this->request->getFormat() !== 'rss') {
+                $pagination = $this->getPagination($posts, $currentPage);
+            }
             $this->view->assign('type', 'bycategory');
             $this->view->assign('posts', $posts);
-            $this->view->assign('pagination', $pagination);
+            $this->view->assign('pagination', $pagination ?? null);
             $this->view->assign('category', $category);
             MetaTagService::set(MetaTagService::META_TITLE, (string) $category->getTitle());
             MetaTagService::set(MetaTagService::META_DESCRIPTION, (string) $category->getDescription());
@@ -217,11 +237,16 @@ class PostController extends ActionController
     public function listPostsByAuthorAction(?Author $author = null, int $currentPage = 1): ResponseInterface
     {
         if ($author !== null) {
-            $posts = $this->postRepository->findAllByAuthor($author);
-            $pagination = $this->getPagination($posts, $currentPage);
+            if ($this->request->getFormat() === 'rss') {
+                $maximumItems = (int) ($this->settings['rss']['maximumDisplayedItems'] ?? 10);
+            }
+            $posts = $this->postRepository->findAllByAuthorWithLimit($author, $maximumItems ?? 0);
+            if ($this->request->getFormat() !== 'rss') {
+                $pagination = $this->getPagination($posts, $currentPage);
+            }
             $this->view->assign('type', 'byauthor');
             $this->view->assign('posts', $posts);
-            $this->view->assign('pagination', $pagination);
+            $this->view->assign('pagination', $pagination ?? null);
             $this->view->assign('author', $author);
             MetaTagService::set(MetaTagService::META_TITLE, (string) $author->getName());
             MetaTagService::set(MetaTagService::META_DESCRIPTION, (string) $author->getBio());
@@ -237,11 +262,16 @@ class PostController extends ActionController
     public function listPostsByTagAction(?Tag $tag = null, int $currentPage = 1): ResponseInterface
     {
         if ($tag !== null) {
-            $posts = $this->postRepository->findAllByTag($tag);
-            $pagination = $this->getPagination($posts, $currentPage);
+            if ($this->request->getFormat() === 'rss') {
+                $maximumItems = (int) ($this->settings['rss']['maximumDisplayedItems'] ?? 10);
+            }
+            $posts = $this->postRepository->findAllByTagWithLimit($tag, $maximumItems ?? 0);
+            if ($this->request->getFormat() !== 'rss') {
+                $pagination = $this->getPagination($posts, $currentPage);
+            }
             $this->view->assign('type', 'bytag');
             $this->view->assign('posts', $posts);
-            $this->view->assign('pagination', $pagination);
+            $this->view->assign('pagination', $pagination ?? null);
             $this->view->assign('tag', $tag);
             MetaTagService::set(MetaTagService::META_TITLE, (string) $tag->getTitle());
             MetaTagService::set(MetaTagService::META_DESCRIPTION, (string) $tag->getDescription());

--- a/Classes/Controller/PostController.php
+++ b/Classes/Controller/PostController.php
@@ -91,9 +91,16 @@ class PostController extends ActionController
                 default:
             }
 
+            $title = '' !== ($this->settings['rss']['title'] ?? '')
+                ? $this->settings['rss']['title']
+                : LocalizationUtility::translate('feed.title' . $action, 'blog', $arguments);
+            $description = '' !== ($this->settings['rss']['description'] ?? '')
+                ? $this->settings['rss']['description']
+                : LocalizationUtility::translate('feed.description' . $action, 'blog', $arguments);
+
             $feedData = [
-                'title' => ($this->settings['rss']['title'] ?? false) ?: LocalizationUtility::translate('feed.title' . $action, 'blog', $arguments),
-                'description' => ($this->settings['rss']['description'] ?? false) ?: LocalizationUtility::translate('feed.description' . $action, 'blog', $arguments),
+                'title' => $title,
+                'description' => $description,
                 'language' => $this->getSiteLanguage()->getLocale()->getLanguageCode(),
                 'link' => $this->getRequestUrl(),
                 'date' => date('r'),

--- a/Classes/Domain/Repository/PostRepository.php
+++ b/Classes/Domain/Repository/PostRepository.php
@@ -199,6 +199,11 @@ class PostRepository extends Repository
 
     public function findAllByAuthor(Author $author): QueryResultInterface
     {
+        return $this->findAllByAuthorWithLimit($author);
+    }
+
+    public function findAllByAuthorWithLimit(Author $author, int $limit = 0): QueryResultInterface
+    {
         $query = $this->createQuery();
         $constraints = $this->defaultConstraints;
         $storagePidConstraint = $this->getStoragePidConstraint();
@@ -206,11 +211,19 @@ class PostRepository extends Repository
             $constraints[] = $storagePidConstraint;
         }
         $constraints[] = $query->contains('authors', $author);
+        if ($limit > 0) {
+            $query->setLimit($limit);
+        }
 
         return $query->matching($query->logicalAnd(...$constraints))->execute();
     }
 
     public function findAllByCategory(Category $category): QueryResultInterface
+    {
+        return $this->findAllByCategoryWithLimit($category);
+    }
+
+    public function findAllByCategoryWithLimit(Category $category, int $limit = 0): QueryResultInterface
     {
         $query = $this->createQuery();
         $constraints = $this->defaultConstraints;
@@ -219,11 +232,19 @@ class PostRepository extends Repository
         if ($storagePidConstraint instanceof ComparisonInterface) {
             $constraints[] = $storagePidConstraint;
         }
+        if ($limit > 0) {
+            $query->setLimit($limit);
+        }
 
         return $query->matching($query->logicalAnd(...$constraints))->execute();
     }
 
     public function findAllByTag(Tag $tag): QueryResultInterface
+    {
+        return $this->findAllByTagWithLimit($tag);
+    }
+
+    public function findAllByTagWithLimit(Tag $tag, int $limit = 0): QueryResultInterface
     {
         $query = $this->createQuery();
         $constraints = $this->defaultConstraints;
@@ -232,11 +253,19 @@ class PostRepository extends Repository
         if ($storagePidConstraint instanceof ComparisonInterface) {
             $constraints[] = $storagePidConstraint;
         }
+        if ($limit > 0) {
+            $query->setLimit($limit);
+        }
 
         return $query->matching($query->logicalAnd(...$constraints))->execute();
     }
 
     public function findByMonthAndYear(int $year, ?int $month = null): QueryResultInterface
+    {
+        return $this->findByMonthAndYearWithLimit($year, $month);
+    }
+
+    public function findByMonthAndYearWithLimit(int $year, ?int $month = null, int $limit = 0): QueryResultInterface
     {
         $query = $this->createQuery();
         $constraints = $this->defaultConstraints;
@@ -254,6 +283,9 @@ class PostRepository extends Repository
         }
         $constraints[] = $query->greaterThanOrEqual('publish_date', $startDate->getTimestamp());
         $constraints[] = $query->lessThanOrEqual('publish_date', $endDate->getTimestamp());
+        if ($limit > 0) {
+            $query->setLimit($limit);
+        }
 
         return $query->matching($query->logicalAnd(...$constraints))->execute();
     }

--- a/Configuration/Sets/Static/settings.definitions.yaml
+++ b/Configuration/Sets/Static/settings.definitions.yaml
@@ -38,6 +38,8 @@ categories:
     parent: blog
   blog.notifications:
     parent: blog
+  blog.rss:
+    parent: blog
 
   blog_post:
   blog_post.featuredimage:
@@ -728,3 +730,20 @@ settings:
     category: blog.notifications
     type: string
     default: 'admin@example.com'
+
+
+
+  plugin.tx_blog.settings.rss.title:
+    category: blog.rss
+    type: string
+    default: ''
+
+  plugin.tx_blog.settings.rss.description:
+    category: blog.rss
+    type: string
+    default: ''
+
+  plugin.tx_blog.settings.rss.maximumDisplayedItems:
+    category: blog.rss
+    type: int
+    default: 10

--- a/Configuration/Sets/Static/setup.typoscript
+++ b/Configuration/Sets/Static/setup.typoscript
@@ -317,6 +317,13 @@ plugin.tx_blog {
                 }
             }
         }
+
+        # RSS related settings
+        rss {
+            title = {$plugin.tx_blog.settings.rss.title}
+            description = {$plugin.tx_blog.settings.rss.description}
+            maximumDisplayedItems = {$plugin.tx_blog.settings.rss.maximumDisplayedItems}
+        }
     }
 
     pageInfo.title = TEXT

--- a/Resources/Private/Partials/List.rss
+++ b/Resources/Private/Partials/List.rss
@@ -1,12 +1,5 @@
-<f:if condition="{pagination} && {pagination.paginatedItems}">
-    <f:then>
-        <f:for each="{pagination.paginatedItems}" iteration="iterator" as="post">
-            <f:render partial="List/Post" arguments="{_all}" />
-        </f:for>
-    </f:then>
-    <f:else if="{posts}">
-        <f:for each="{posts}" iteration="iterator" as="post">
-            <f:render partial="List/Post" arguments="{_all}" />
-        </f:for>
-    </f:else>
+<f:if condition="{posts}">
+    <f:for each="{posts}" iteration="iterator" as="post">
+        <f:render partial="List/Post" arguments="{_all}" />
+    </f:for>
 </f:if>


### PR DESCRIPTION
Prior to introducing these settings, pagination implicitly limited all RSS feeds to 10 items. To maintain this behavior and match with the existing default value of `plugin.tx_blog.settings.lists.posts.maximumDisplayedItems`, the default value for `plugin.tx_blog.settings.rss.maximumDisplayedItems` is set to 10.

Behavior of existing installations only changes if the respective list limit is lower than 10. In that case `plugin.tx_blog.settings.rss.maximumDisplayedItems` must be set to the desired value. Otherwise its default value (10) will be used.