### PR TITLE
[BUGFIX] Always return real category parent instance for Fluid access

### DIFF
--- a/Classes/Domain/Model/Category.php
+++ b/Classes/Domain/Model/Category.php
@@ -27,7 +27,7 @@ class Category extends AbstractEntity
     protected int $recordType = Constants::CATEGORY_TYPE_BLOG;
 
     /**
-     * @var \T3G\AgencyPack\Blog\Domain\Model\Category
+     * @var \T3G\AgencyPack\Blog\Domain\Model\Category|LazyLoadingProxy
      * @Extbase\ORM\Lazy
      */
     protected $parent;
@@ -90,7 +90,9 @@ class Category extends AbstractEntity
     public function getParent(): ?self
     {
         if ($this->parent instanceof LazyLoadingProxy) {
-            $this->parent = $this->parent->_loadRealInstance();
+            /** @var self $parentCategory */
+            $parentCategory = $this->parent->_loadRealInstance();
+            $this->parent = $parentCategory;
         }
         return $this->parent;
     }

--- a/Classes/Domain/Model/Category.php
+++ b/Classes/Domain/Model/Category.php
@@ -87,8 +87,11 @@ class Category extends AbstractEntity
         return $this;
     }
 
-    public function getParent(): null|self|LazyLoadingProxy
+    public function getParent(): ?self
     {
+        if ($this->parent instanceof LazyLoadingProxy) {
+            $this->parent = $this->parent->_loadRealInstance();
+        }
         return $this->parent;
     }
 


### PR DESCRIPTION
Fluid can not access LazyLoadingProxy's real instance properties directly.
Therefore, we always return the real instance now, rather than returning the proxy object.