### PR TITLE
[TASK] Use associative keys in FlexForm items

### DIFF
--- a/Configuration/FlexForms/Demand.xml
+++ b/Configuration/FlexForms/Demand.xml
@@ -49,12 +49,12 @@
                             <renderType>selectSingle</renderType>
                             <items type="array">
                                 <numIndex index="0" type="array">
-                                    <numIndex index="0">LLL:EXT:blog/Resources/Private/Language/locallang_db.xlf:settings.demand.categoriesConjunction.AND</numIndex>
-                                    <numIndex index="1">AND</numIndex>
+                                    <label>LLL:EXT:blog/Resources/Private/Language/locallang_db.xlf:settings.demand.categoriesConjunction.AND</label>
+                                    <value>AND</value>
                                 </numIndex>
                                 <numIndex index="1" type="array">
-                                    <numIndex index="0">LLL:EXT:blog/Resources/Private/Language/locallang_db.xlf:settings.demand.categoriesConjunction.OR</numIndex>
-                                    <numIndex index="1">OR</numIndex>
+                                    <label>LLL:EXT:blog/Resources/Private/Language/locallang_db.xlf:settings.demand.categoriesConjunction.OR</label>
+                                    <value>OR</value>
                                 </numIndex>
                             </items>
                         </config>
@@ -77,12 +77,12 @@
                             <renderType>selectSingle</renderType>
                             <items type="array">
                                 <numIndex index="0" type="array">
-                                    <numIndex index="0">LLL:EXT:blog/Resources/Private/Language/locallang_db.xlf:settings.demand.tagsConjunction.AND</numIndex>
-                                    <numIndex index="1">AND</numIndex>
+                                    <label>LLL:EXT:blog/Resources/Private/Language/locallang_db.xlf:settings.demand.tagsConjunction.AND</label>
+                                    <value>AND</value>
                                 </numIndex>
                                 <numIndex index="1" type="array">
-                                    <numIndex index="0">LLL:EXT:blog/Resources/Private/Language/locallang_db.xlf:settings.demand.tagsConjunction.OR</numIndex>
-                                    <numIndex index="1">OR</numIndex>
+                                    <label>LLL:EXT:blog/Resources/Private/Language/locallang_db.xlf:settings.demand.tagsConjunction.OR</label>
+                                    <value>OR</value>
                                 </numIndex>
                             </items>
                         </config>
@@ -95,12 +95,12 @@
                             <renderType>selectSingle</renderType>
                             <items type="array">
                                 <numIndex index="0" type="array">
-                                    <numIndex index="0">LLL:EXT:blog/Resources/Private/Language/locallang_db.xlf:pages.publish_date</numIndex>
-                                    <numIndex index="1">publish_date</numIndex>
+                                    <label>LLL:EXT:blog/Resources/Private/Language/locallang_db.xlf:pages.publish_date</label>
+                                    <value>publish_date</value>
                                 </numIndex>
                                 <numIndex index="1" type="array">
-                                    <numIndex index="0">LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.title_formlabel</numIndex>
-                                    <numIndex index="1">title</numIndex>
+                                    <label>LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.title_formlabel</label>
+                                    <value>title</value>
                                 </numIndex>
                             </items>
                         </config>
@@ -113,12 +113,12 @@
                             <renderType>selectSingle</renderType>
                             <items type="array">
                                 <numIndex index="0" type="array">
-                                    <numIndex index="0">LLL:EXT:blog/Resources/Private/Language/locallang_db.xlf:settings.demand.sortDirection.ASC</numIndex>
-                                    <numIndex index="1">ASC</numIndex>
+                                    <label>LLL:EXT:blog/Resources/Private/Language/locallang_db.xlf:settings.demand.sortDirection.ASC</label>
+                                    <value>ASC</value>
                                 </numIndex>
                                 <numIndex index="1" type="array">
-                                    <numIndex index="0">LLL:EXT:blog/Resources/Private/Language/locallang_db.xlf:settings.demand.sortDirection.DESC</numIndex>
-                                    <numIndex index="1">DESC</numIndex>
+                                    <label>LLL:EXT:blog/Resources/Private/Language/locallang_db.xlf:settings.demand.sortDirection.DESC</label>
+                                    <value>DESC</value>
                                 </numIndex>
                             </items>
                             <default>DESC</default>

--- a/Configuration/FlexForms/Posts.xml
+++ b/Configuration/FlexForms/Posts.xml
@@ -16,8 +16,8 @@
                             <renderType>selectSingle</renderType>
                             <items type="array">
                                 <numIndex index="0" type="array">
-                                    <numIndex index="0">LLL:EXT:blog/Resources/Private/Language/locallang_db.xlf:settings.lists.posts.layout.default</numIndex>
-                                    <numIndex index="1">default</numIndex>
+                                    <label>LLL:EXT:blog/Resources/Private/Language/locallang_db.xlf:settings.lists.posts.layout.default</label>
+                                    <value>default</value>
                                 </numIndex>
                             </items>
                             <default>default</default>


### PR DESCRIPTION
## What the core reports today

Both shipped data structures define their select items positionally — `numIndex 0`
as the label, `numIndex 1` as the value. `TcaMigration` rewrites that shape on every
uncached request and says so:

> FlexFormTools did an on-the-fly migration of a flex form data structure. This is
> deprecated and will be removed. […] uses the legacy way of defining 'items'.
> Please switch to associated array keys: label, value, icon, group, description.

Five entries: `settings.lists.posts.layout` in `Posts.xml`, and
`settings.demand.categoriesConjunction`, `tagsConjunction`, `sortBy`,
`sortDirection` in `Demand.xml`.

## The change

```diff
 <numIndex index="0" type="array">
-    <numIndex index="0">LLL:…:settings.demand.sortDirection.ASC</numIndex>
-    <numIndex index="1">ASC</numIndex>
+    <label>LLL:…:settings.demand.sortDirection.ASC</label>
+    <value>ASC</value>
 </numIndex>
```

`label` / `value` is exactly the shape `TcaMigration` produces (`TcaMigration.php:1400-1407`),
and associative item keys exist since **TYPO3 12.3** (Feature #99739) — so this holds
on both declared majors.

**Only the keys change. Every stored value stays as it was**, which matters because
the value is what existing content records hold.

## Verification

Reading the parsed data structures back through `GeneralUtility::xml2array` on both
majors — all nine items arrive with the associative keys and unchanged values:

```
TYPO3 13.4.34                          TYPO3 14.3.6
  settings.demand.sortDirection          settings.demand.sortDirection
      [0] keys=label,value  value='ASC'      [0] keys=label,value  value='ASC'
      [1] keys=label,value  value='DESC'     [1] keys=label,value  value='DESC'
  settings.lists.posts.layout            settings.lists.posts.layout
      [0] keys=label,value value='default'   [0] keys=label,value value='default'
```

| Check | TYPO3 13.4.34 | TYPO3 14.3.6 |
| --- | --- | --- |
| `composer test:php:functional` | 119 tests, 234 assertions, OK, **no deprecations** | 119 tests, 234 assertions, OK, **deprecations 12 → 7** |
| `composer test:php:unit` | — | 27 tests, 34 assertions, OK |
| `composer phpstan` | — | no errors |
| `composer test:php:lint` | — | 145 files OK |
| `php-cs-fixer --dry-run` | — | 0 of 144 |

The five removed deprecations are exactly the FlexForm ones; the remaining seven are
`ext_emconf.php`, `addPiFlexFormValue`, `versioningWS`, `ext_tables.php` (twice),
`PageDoktypeRegistry` and `locationHeaderUrl` — each tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
